### PR TITLE
Hide overflow when notification in full width

### DIFF
--- a/src/Toast/toast.module.css
+++ b/src/Toast/toast.module.css
@@ -11,6 +11,10 @@
   --large: 75%;
 }
 
+body {
+  overflow: hidden;
+}
+
 .toast {
   display: flex;
   border: var(--border-size) solid var(--border-color);


### PR DESCRIPTION
Hello, 

I loved your project. I have found an issue about including full width support I was wondering to work on it but you had already done. 

I noticed that when we select to generate the widget in `full width`, a scroll is show on the bottom of the page:

![image](https://user-images.githubusercontent.com/13206817/139502561-e48dee9a-d29d-4b27-a01a-014fffa1b7f1.png)

This PR will fix this:

![image](https://user-images.githubusercontent.com/13206817/139502694-3ba0ae06-3d89-459d-9890-733386c28b3f.png)


